### PR TITLE
fix: allow modal to be scrollable in body

### DIFF
--- a/alca-app/src/pages/Transactions/Transactions.jsx
+++ b/alca-app/src/pages/Transactions/Transactions.jsx
@@ -428,6 +428,7 @@ export function Transactions() {
                 onClose={() => {
                     setModalOpen(false);
                 }}
+                sx={{ overflow: "auto" }}
             >
                 <Box
                     sx={{


### PR DESCRIPTION
## Issue
When modal content is longer than window size, you can't get to the content at the bottom