### PR TITLE
fix: disable ctas in regard to block #

### DIFF
--- a/alca-app/src/pages/Positions/Positions.jsx
+++ b/alca-app/src/pages/Positions/Positions.jsx
@@ -248,7 +248,7 @@ export function Positions() {
                             onClick={() => {
                                 handleShowUnstakeModal(params.row);
                             }}
-                            disabled={!canUnstake()}
+                            disabled={!canUnstake(params)}
                         >
                             Unstake
                         </Button>

--- a/alca-app/src/pages/Positions/Positions.jsx
+++ b/alca-app/src/pages/Positions/Positions.jsx
@@ -175,6 +175,15 @@ export function Positions() {
         setCurrentTab(newValue);
     };
 
+    function canClaimRewards(params) {
+        const hasRewards = parseFloat(params.row.alcaRewards) > 0 || parseFloat(params.row.ethRewards) > 0;
+        return !transacting && hasRewards && Number(currentBlock) > Number(params.row.claimRewardsAfter);
+    }
+
+    function canUnstake(params) {
+        return !transacting && Number(currentBlock) > Number(params.row.unstakePositionAfter);
+    }
+
     const stakedPositionsColumns = [
         {
             field: "amount",
@@ -217,8 +226,6 @@ export function Positions() {
             showColumnRightBorder: false,
             headerClassName: "headerClass",
             renderCell: (params) => {
-                const hasRewards = parseFloat(params.row.alcaRewards) > 0 || parseFloat(params.row.ethRewards) > 0;
-
                 return (
                     <Box display="flex">
                         <Button
@@ -229,11 +236,7 @@ export function Positions() {
                             onClick={() => {
                                 handleClaim(params.row.id);
                             }}
-                            disabled={
-                                transacting ||
-                                !hasRewards ||
-                                Number(currentBlock) <= Number(params.row.claimRewardsAfter)
-                            }
+                            disabled={!canClaimRewards(params)}
                         >
                             Claim Rewards
                         </Button>
@@ -245,7 +248,7 @@ export function Positions() {
                             onClick={() => {
                                 handleShowUnstakeModal(params.row);
                             }}
-                            disabled={transacting || Number(currentBlock) <= Number(params.row.unstakePositionAfter)}
+                            disabled={!canUnstake()}
                         >
                             Unstake
                         </Button>

--- a/alca-app/src/pages/Positions/Positions.jsx
+++ b/alca-app/src/pages/Positions/Positions.jsx
@@ -229,7 +229,11 @@ export function Positions() {
                             onClick={() => {
                                 handleClaim(params.row.id);
                             }}
-                            disabled={transacting || !hasRewards}
+                            disabled={
+                                transacting ||
+                                !hasRewards ||
+                                Number(currentBlock) <= Number(params.row.claimRewardsAfter)
+                            }
                         >
                             Claim Rewards
                         </Button>
@@ -241,7 +245,7 @@ export function Positions() {
                             onClick={() => {
                                 handleShowUnstakeModal(params.row);
                             }}
-                            disabled={transacting}
+                            disabled={transacting || Number(currentBlock) <= Number(params.row.unstakePositionAfter)}
                         >
                             Unstake
                         </Button>


### PR DESCRIPTION
Start comparing `currentBlock` value against `claimRewardsAfter` and  `unstakePositionAfter` in order to decide when buttons should be disabled.